### PR TITLE
feat: add java job structure

### DIFF
--- a/app/java/Procfile
+++ b/app/java/Procfile
@@ -1,0 +1,2 @@
+web: java -jar target/cloud-client-api-0.1.0.jar
+process: java -jar target/cloud-client-api-0.1.0-processingjob.jar

--- a/app/java/pom.xml
+++ b/app/java/pom.xml
@@ -13,10 +13,10 @@ limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.cloudrun</groupId>
-  <artifactId>template-cloud-client-api</artifactId>
+  <groupId>com.google</groupId>
+  <artifactId>cloud-client-api</artifactId>
   <version>0.1.0</version>
-  <name>>template-cloud-client-api</name>
+  <name>cloud-client-api</name>
   <description>Terraform Cloud Client API</description>
 
   <properties>
@@ -64,33 +64,28 @@ limitations under the License.
       <artifactId>google-cloud-core</artifactId>
       <version>2.28.0</version>
     </dependency>
-
-        <!-- web mvc -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-
-        <!-- thymeleaf -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-thymeleaf</artifactId>
-        </dependency>
-
-        <!-- test -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- hot swapping, disable cache for template, enable live reload -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-            <optional>true</optional>
-        </dependency>
-
+    <!-- web mvc -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <!-- thymeleaf -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-thymeleaf</artifactId>
+    </dependency>
+    <!-- test -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-test</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <!-- hot swapping, disable cache for template, enable live reload -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-devtools</artifactId>
+        <optional>true</optional>
+    </dependency>
     <!-- Optionally include development tools -->
     <!-- Provides Automatic Restart functionality -->
     <dependency>
@@ -108,6 +103,7 @@ limitations under the License.
       <optional>true</optional>
     </dependency>
 
+    <!--- Testing depedencies -->
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
@@ -130,6 +126,8 @@ limitations under the License.
 
   <build>
     <plugins>
+
+      <!--- Build Springboot-->
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
@@ -143,17 +141,30 @@ limitations under the License.
         </executions>
       </plugin>
 
+      <!--- Build a separate JAR file for the processing job.  -->
       <plugin>
-        <groupId>com.google.cloud.tools</groupId>
-        <artifactId>jib-maven-plugin</artifactId>
-        <version>3.4.0</version>
-        <configuration>
-          <to>
-            <image>gcr.io/glasnt/TODO-fix-this</image>
-          </to>
-        </configuration>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>ProcessingJob</id>
+            <goals><goal>jar</goal></goals>
+            <phase>package</phase>
+            <configuration>
+              <classifier>processingjob</classifier>
+              <archive>
+                <manifest>
+                  <addClasspath>true</addClasspath>
+                  <mainClass>com.google.cloudclientapi.ProcessingJob</mainClass>
+                </manifest>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
+      <!--- Linting (TODO: confirm usage)-->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>

--- a/app/java/project.toml
+++ b/app/java/project.toml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [[build.env]]
   name = "GOOGLE_RUNTIME_VERSION"
   value = "18"

--- a/app/java/src/main/java/com/google/cloudclientapi/ProcessingJob.java
+++ b/app/java/src/main/java/com/google/cloudclientapi/ProcessingJob.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+
 //
-// ProcessingJob.java - take data in raw_data bucket, 
+// ProcessingJob.java - take data in raw_data bucket,
 //                      process, and store in processed bucket.
 //
 
@@ -31,7 +32,7 @@ abstract class ProcessingJob {
     System.out.println(
         String.format(
             "🟢 Start process.py with: %s, %s", RAW_DATA_BUCKET, PROCESSED_DATA_BUCKET));
-    
+
     // TODO: real processing.
     System.out.println("TODO: IMPLEMENTATION");
   }

--- a/app/java/src/main/java/com/google/cloudclientapi/ProcessingJob.java
+++ b/app/java/src/main/java/com/google/cloudclientapi/ProcessingJob.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// ProcessingJob.java - take data in raw_data bucket, 
+//                      process, and store in processed bucket.
+//
+
+package com.google.cloudclientapi;
+
+abstract class ProcessingJob {
+  private static String RAW_DATA_BUCKET =
+      System.getenv().get("RAW_DATA_BUCKET");
+  private static String PROCESSED_DATA_BUCKET =
+      System.getenv().get("PROCESSED_DATA_BUCKET");
+
+  public static void main(String[] args) {
+    System.out.println(
+        String.format(
+            "🟢 Start process.py with: %s, %s", RAW_DATA_BUCKET, PROCESSED_DATA_BUCKET));
+    
+    // TODO: real processing.
+    System.out.println("TODO: IMPLEMENTATION");
+  }
+}


### PR DESCRIPTION
Unconventional setup, but allows the Java app to be called like the Python app, with a Procfile, and having the ability to have the job definition in the same folder as the service to allow for any resource/import sharing, as required during development. 