### PR TITLE
fix: Use alphabetical graph label order

### DIFF
--- a/app/java/src/main/resources/templates/index.html
+++ b/app/java/src/main/resources/templates/index.html
@@ -85,7 +85,7 @@
         line_col = "#8e39a7"
 
         const data = {
-            labels: ['Running', 'Climbing', 'Chasing', 'Eating', 'Foraging'],
+            labels: ['Running', 'Chasing', 'Climbing', 'Eating', 'Foraging'],
             datasets: [
                 {
                     label: 'Squirrels',

--- a/app/nodejs/views/index.handlebars
+++ b/app/nodejs/views/index.handlebars
@@ -85,7 +85,7 @@
         line_col = "#8e39a7"
 
         const data = {
-            labels: ['Running', 'Climbing', 'Chasing', 'Eating', 'Foraging'],
+            labels: ['Running', 'Chasing', 'Climbing', 'Eating', 'Foraging'],
             datasets: [
                 {
                     label: 'Squirrels',

--- a/app/python/main.py
+++ b/app/python/main.py
@@ -51,7 +51,10 @@ def retrieve_data(fur, age, location):
     squirrel_count = data.pop("_counter")
 
     logging.info(f"Retrieved data for {squirrel_count} entities.")
-    return squirrel_count, list(data.values())
+
+    # Ensure data values are returned ordered by key
+    data_points = list(dict(sorted(data.items())).values())
+    return squirrel_count, data_points
 
 
 @app.route("/")

--- a/app/python/templates/index.html
+++ b/app/python/templates/index.html
@@ -85,7 +85,7 @@
         line_col = "#8e39a7"
 
         const data = {
-            labels: ['Running', 'Climbing', 'Chasing', 'Eating', 'Foraging'],
+            labels: ['Running', 'Chasing', 'Climbing', 'Eating', 'Foraging'],
             datasets: [
                 {
                     label: 'Squirrels',

--- a/app/python/tests/test_process.py
+++ b/app/python/tests/test_process.py
@@ -36,6 +36,7 @@ def test_process_raw_data():
     assert "Black/Juvenile/Ground Plane" in results.keys()
 
     # Validate a specific aggregate result
-    old_tree_sq = results["Gray/Adult/Above Ground"]
-    assert old_tree_sq["_counter"] == 561
-    assert old_tree_sq["Running"] == 114
+    sample = results["Gray/Adult/Above Ground"]
+    assert sample["_counter"] == 561
+    assert sample["Running"] == 114
+    assert sample["Chasing"] == 63

--- a/app/templates/index.html.tmpl
+++ b/app/templates/index.html.tmpl
@@ -84,7 +84,7 @@
         line_col = "#8e39a7"
 
         const data = {
-            labels: ['Running', 'Climbing', 'Chasing', 'Eating', 'Foraging'],
+            labels: ['Running', 'Chasing', 'Climbing', 'Eating', 'Foraging'],
             datasets: [
                 {
                     label: 'Squirrels',


### PR DESCRIPTION
### Background

* Problem: The way that we pass JSON data into the frontend `index.html` template assumes that the spider graph's labels are in alphabetical order.
* See [use of Object.values() in Node.js/JavaScript app](https://github.com/GoogleCloudPlatform/terraform-cloud-client-api/pull/30/files#diff-b2c7a247ec880d38e94235f5f0ee27b467e4940cad92a4ec88af0a004c8a340bR59).
* See [docs about Object.values()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Object/values#description). See [docs about for...in](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in):

> The traversal order, as of modern ECMAScript specification, is well-defined and consistent across implementations. Within each component of the prototype chain, all non-negative integer keys (those that can be array indices) will be traversed first in ascending order by value, then other string keys in ascending chronological order of property creation.

### Solution
* We need to make sure the spider graph's labels are in alphabetical order.

### Caution
* I have not confirmed that this works for Python.