### PR TITLE
fix: Ensure all segments are sorted alphabetically by key

### DIFF
--- a/app/java/src/main/resources/templates/index.html
+++ b/app/java/src/main/resources/templates/index.html
@@ -85,7 +85,7 @@
         line_col = "#8e39a7"
 
         const data = {
-            labels: ['Running', 'Chasing', 'Climbing', 'Eating', 'Foraging'],
+            labels: ['Chasing', 'Climbing', 'Eating', 'Foraging', 'Running'],
             datasets: [
                 {
                     label: 'Squirrels',

--- a/app/nodejs/views/index.handlebars
+++ b/app/nodejs/views/index.handlebars
@@ -85,7 +85,7 @@
         line_col = "#8e39a7"
 
         const data = {
-            labels: ['Running', 'Chasing', 'Climbing', 'Eating', 'Foraging'],
+            labels: ['Chasing', 'Climbing', 'Eating', 'Foraging', 'Running'],
             datasets: [
                 {
                     label: 'Squirrels',

--- a/app/python/config.py
+++ b/app/python/config.py
@@ -39,7 +39,7 @@ PROCESSED_DATA_BUCKET = os.environ.get("PROCESSED_DATA_BUCKET")
 FACETS = ["Primary Fur Color", "Age", "Location"]
 
 # Segmentation to display data by, used for displaying processed data
-SEGMENTS = ["Running", "Chasing", "Climbing", "Eating", "Foraging"]
+SEGMENTS = ["Chasing", "Climbing", "Eating", "Foraging", "Running"]
 
 
 # Setup integrated logging https://cloud.google.com/logging/docs/setup/python

--- a/app/python/templates/index.html
+++ b/app/python/templates/index.html
@@ -85,7 +85,7 @@
         line_col = "#8e39a7"
 
         const data = {
-            labels: ['Running', 'Chasing', 'Climbing', 'Eating', 'Foraging'],
+            labels: ['Chasing', 'Climbing', 'Eating', 'Foraging', 'Running'],
             datasets: [
                 {
                     label: 'Squirrels',

--- a/app/templates/index.html.tmpl
+++ b/app/templates/index.html.tmpl
@@ -84,7 +84,7 @@
         line_col = "#8e39a7"
 
         const data = {
-            labels: ['Running', 'Chasing', 'Climbing', 'Eating', 'Foraging'],
+            labels: ['Chasing', 'Climbing', 'Eating', 'Foraging', 'Running'],
             datasets: [
                 {
                     label: 'Squirrels',


### PR DESCRIPTION
As raised by @NimJay in #36, the ordering of dictionary/object keys in different programming languages are handled differently. 

This implements absolute alphabetical sorting to the segment keys. This PR will be merged and rebased into the WIP language implementations #30, #32, and integration testing added in #35 to ensure correct ordering of queried data. 