### PR TITLE
fix: add link to postdeploy neos

### DIFF
--- a/app/java/src/main/resources/templates/index.html
+++ b/app/java/src/main/resources/templates/index.html
@@ -129,7 +129,9 @@
 
     </span><span th:unless="${squirrel_count} > 0">
 
-    <div>No data available. <a href="#">Follow the tutorial instructions</a>.</div>
+    <div>No data available.
+        <a href="https://console.cloud.google.com/?walkthrough_id=solutions-in-console--cloud-client-api--cloud-client-api_postdeploy" target=_blank>Follow the tutorial instructions</a>.
+    </div>
 
     </span>
 

--- a/app/nodejs/views/index.handlebars
+++ b/app/nodejs/views/index.handlebars
@@ -129,7 +129,9 @@
 
     {{else}}
 
-    <div>No data available. <a href="#">Follow the tutorial instructions</a>.</div>
+    <div>No data available.
+        <a href="https://console.cloud.google.com/?walkthrough_id=solutions-in-console--cloud-client-api--cloud-client-api_postdeploy" target=_blank>Follow the tutorial instructions</a>.
+    </div>
 
     {{/if}}
 

--- a/app/python/templates/index.html
+++ b/app/python/templates/index.html
@@ -129,7 +129,9 @@
 
     {% else %}
 
-    <div>No data available. <a href="#">Follow the tutorial instructions</a>.</div>
+    <div>No data available.
+        <a href="https://console.cloud.google.com/?walkthrough_id=solutions-in-console--cloud-client-api--cloud-client-api_postdeploy" target=_blank>Follow the tutorial instructions</a>.
+    </div>
 
     {% endif %}
 

--- a/app/templates/index.html.tmpl
+++ b/app/templates/index.html.tmpl
@@ -128,7 +128,9 @@
 
     ##ELSE
 
-    <div>No data available. <a href="#">Follow the tutorial instructions</a>.</div>
+    <div>No data available.
+        <a href="https://console.cloud.google.com/?walkthrough_id=solutions-in-console--cloud-client-api--cloud-client-api_postdeploy" target=_blank>Follow the tutorial instructions</a>.
+    </div>
 
     ##ENDIF
 


### PR DESCRIPTION
When a user first deploys the solution, the bucket exists, but there is no data. The template will show this information, and then link to the post-deployment tutorial to prompt the user to complete the process. (This is also the first tutorial in the TOC)