### PR TITLE
fix: add ignore for maven-wrapper

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>GoogleCloudPlatform/cloud-foundation-toolkit//infra/terraform/test-org/github/resources/renovate"]
+  "extends": ["github>GoogleCloudPlatform/cloud-foundation-toolkit//infra/terraform/test-org/github/resources/renovate"],
+  "ignoreDeps": ["maven-wrapper"]
 }


### PR DESCRIPTION
Update renovate configuration as per https://docs.renovatebot.com/configuration-options/#ignoredeps to remove maven-wrapper updates. As per conversation in previous PR #74 this may lead to unpredictable behaviors/broken builds. Better to hand upgrade as needed. 