### PR TITLE
docs: Include go/jss-up6-admin in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,6 @@ Thank you for opening a Pull Request! Before submitting your PR, there are a few
 - [ ] Ensure the tests and linter pass
 - [ ] Communicate test infrastructure changes, i.e. API enablement, secrets
 - [ ] Appropriate docs were updated (if necessary)
+- [ ] If you're a Googler, familiarize yourself with [go/jss-up6-admin](http://go/jss-up6-admin)
 
 🛠️ Fixes #<issue_number_goes_here>


### PR DESCRIPTION
* This pull-request adds the Google-internal doc, [go/jss-up6-admin](http://go/jss-up6-admin), to the pull-request template.