### PR TITLE
fix: Add 500 response for missing env var in Java

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -51,3 +51,4 @@ jobs:
       - run: docker run --rm -e ENABLE_BPMETADATA -v ${{ github.workspace }}:/workspace ${{ steps.variables.outputs.dev-tools }} /usr/local/bin/test_lint.sh
         env:
           ENABLE_BPMETADATA: 1
+

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -48,7 +48,7 @@ jobs:
         env:
           ENABLE_BPMETADATA: 1
 
-      - run: docker run --rm -e ENABLE_BPMETADATA -v ${{ github.workspace }}:/workspace ${{ steps.variables.outputs.dev-tools }} /usr/local/bin/test_lint.sh
+      - run: docker run --rm -e ENABLE_BPMETADATA -e EXCLUDE_LINT_DIRS -v ${{ github.workspace }}:/workspace ${{ steps.variables.outputs.dev-tools }} /usr/local/bin/test_lint.sh
         env:
           ENABLE_BPMETADATA: 1
-
+          EXCLUDE_LINT_DIRS: \./app/java/.mvn/wrapper/maven-wrapper.jar

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -48,7 +48,6 @@ jobs:
         env:
           ENABLE_BPMETADATA: 1
 
-      - run: docker run --rm -e ENABLE_BPMETADATA -e EXCLUDE_LINT_DIRS -v ${{ github.workspace }}:/workspace ${{ steps.variables.outputs.dev-tools }} /usr/local/bin/test_lint.sh
+      - run: docker run --rm -e ENABLE_BPMETADATA -v ${{ github.workspace }}:/workspace ${{ steps.variables.outputs.dev-tools }} /usr/local/bin/test_lint.sh
         env:
           ENABLE_BPMETADATA: 1
-          EXCLUDE_LINT_DIRS: \./app/java/.mvn/wrapper/maven-wrapper.jar

--- a/app/java/src/main/java/com/google/cloudclientapi/CensusController.java
+++ b/app/java/src/main/java/com/google/cloudclientapi/CensusController.java
@@ -32,7 +32,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @Controller
 public class CensusController {
 
-  private static final String PROCESSED_DATA_BUCKET = System.getenv().get("PROCESSED_DATA_BUCKET");
   private static final Logger logger = LoggerFactory.getLogger(CensusController.class);
 
   @GetMapping("/")
@@ -44,7 +43,8 @@ public class CensusController {
       Model model) {
     logger.info("Request received for fur: {}, age: {}, location: {}", fur, age, location);
 
-    if (PROCESSED_DATA_BUCKET == null || PROCESSED_DATA_BUCKET.isEmpty()) {
+    if (EnvironmentVars.get("PROCESSED_DATA_BUCKET") == null
+        || EnvironmentVars.get("PROCESSED_DATA_BUCKET").isEmpty()) {
       throw new UnspecifiedProcessedDataBucketException();
     }
 
@@ -80,7 +80,9 @@ public class CensusController {
    */
   public SquirrelSegment retrieveData(String fur, String age, String location) {
     String filePath = fur + "/" + age + "/" + location + "/data.json";
-    String jsonAsString = GoogleCloudStorage.downloadFileAsString(PROCESSED_DATA_BUCKET, filePath);
+    String jsonAsString =
+        GoogleCloudStorage.downloadFileAsString(
+            EnvironmentVars.get("PROCESSED_DATA_BUCKET"), filePath);
     if (jsonAsString == null) {
       return null;
     }

--- a/app/java/src/main/java/com/google/cloudclientapi/CensusController.java
+++ b/app/java/src/main/java/com/google/cloudclientapi/CensusController.java
@@ -21,10 +21,13 @@ import java.util.Arrays;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Controller
 public class CensusController {
@@ -40,6 +43,10 @@ public class CensusController {
           String location,
       Model model) {
     logger.info("Request received for fur: {}, age: {}, location: {}", fur, age, location);
+
+    if (PROCESSED_DATA_BUCKET == null || PROCESSED_DATA_BUCKET.isEmpty()) {
+      throw new UnspecifiedProcessedDataBucketException();
+    }
 
     // Default values (which would be rendered as "No data available.").
     model.addAttribute("squirrel_count", 0);
@@ -81,5 +88,11 @@ public class CensusController {
     SquirrelSegment squirrelSegment = gson.fromJson(jsonAsString, SquirrelSegment.class);
     logger.info("Retrieved data for {} entities.", squirrelSegment._counter);
     return squirrelSegment;
+  }
+
+  @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+  @ExceptionHandler({UnspecifiedProcessedDataBucketException.class})
+  public String handleUnspecifiedProcessedDataBucketException() {
+    return "error-unspecified-processed-data-bucket";
   }
 }

--- a/app/java/src/main/java/com/google/cloudclientapi/EnvironmentVars.java
+++ b/app/java/src/main/java/com/google/cloudclientapi/EnvironmentVars.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloudclientapi;
+
+/**
+ * This class is used for obtaining values of environment variables. Yes,
+ * System.getenv().get("MY_ENV_VAR") is simple enough already, but java.lang.System cannot be mocked
+ * for unit tests.
+ */
+public class EnvironmentVars {
+  public static String get(String key) {
+    return System.getenv().get(key);
+  }
+}

--- a/app/java/src/main/java/com/google/cloudclientapi/UnspecifiedProcessedDataBucketException.java
+++ b/app/java/src/main/java/com/google/cloudclientapi/UnspecifiedProcessedDataBucketException.java
@@ -1,0 +1,3 @@
+package com.google.cloudclientapi;
+
+public class UnspecifiedProcessedDataBucketException extends RuntimeException {}

--- a/app/java/src/main/java/com/google/cloudclientapi/UnspecifiedProcessedDataBucketException.java
+++ b/app/java/src/main/java/com/google/cloudclientapi/UnspecifiedProcessedDataBucketException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloudclientapi;
 
 public class UnspecifiedProcessedDataBucketException extends RuntimeException {}

--- a/app/java/src/main/resources/templates/error-unspecified-processed-data-bucket.html
+++ b/app/java/src/main/resources/templates/error-unspecified-processed-data-bucket.html
@@ -1,1 +1,17 @@
+<!--
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
 Environment variable PROCESSED_DATA_BUCKET required

--- a/app/java/src/main/resources/templates/error-unspecified-processed-data-bucket.html
+++ b/app/java/src/main/resources/templates/error-unspecified-processed-data-bucket.html
@@ -1,0 +1,1 @@
+Environment variable PROCESSED_DATA_BUCKET required

--- a/app/java/src/test/java/com/google/cloudclientapi/CensusApplicationTest.java
+++ b/app/java/src/test/java/com/google/cloudclientapi/CensusApplicationTest.java
@@ -29,14 +29,27 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
 
 @WebMvcTest(CensusController.class)
 class CensusApplicationTest {
 
-  @Autowired
-  private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-  private final String VALID_SQUIRREL_SEGMENT_JSON = "{\"_counter\":561,\"Chasing\":63,\"Climbing\":361,\"Eating\":102,\"Foraging\":95,\"Running\":114}";
+  private final String VALID_SQUIRREL_SEGMENT_JSON =
+      "{\"_counter\":561,\"Chasing\":63,\"Climbing\":361,\"Eating\":102,\"Foraging\":95,\"Running\":114}";
+
+  @Test
+  public void homePageShouldSayEnvVarRequired() throws Exception {
+    // Mock GoogleCloudStorage
+    try (MockedStatic<GoogleCloudStorage> mockedGcs =
+        Mockito.mockStatic(GoogleCloudStorage.class)) {
+      mockedGcs.when(() -> GoogleCloudStorage.downloadFileAsString(any(), any())).thenReturn(null);
+
+      this.expectAHomePageResponseWith(
+          status().isInternalServerError(), "Environment variable PROCESSED_DATA_BUCKET required");
+    }
+  }
 
   @Test
   public void homePageShouldSayNoDataAvailable() throws Exception {
@@ -47,12 +60,13 @@ class CensusApplicationTest {
           .thenReturn("Placeholder");
 
       // Mock GoogleCloudStorage
-      try (MockedStatic<GoogleCloudStorage> mockedGcs = Mockito.mockStatic(GoogleCloudStorage.class)) {
+      try (MockedStatic<GoogleCloudStorage> mockedGcs =
+          Mockito.mockStatic(GoogleCloudStorage.class)) {
         mockedGcs
             .when(() -> GoogleCloudStorage.downloadFileAsString(any(), any()))
             .thenReturn(null);
 
-        expectAResponseContaining("No data available.");
+        this.expectAHomePageResponseWith(status().isOk(), "No data available.");
       }
     }
   }
@@ -66,21 +80,23 @@ class CensusApplicationTest {
           .thenReturn("Placeholder");
 
       // Mock GoogleCloudStorage
-      try (MockedStatic<GoogleCloudStorage> mockedGcs = Mockito.mockStatic(GoogleCloudStorage.class)) {
+      try (MockedStatic<GoogleCloudStorage> mockedGcs =
+          Mockito.mockStatic(GoogleCloudStorage.class)) {
         mockedGcs
             .when(() -> GoogleCloudStorage.downloadFileAsString(any(), any()))
             .thenReturn(VALID_SQUIRREL_SEGMENT_JSON);
 
-        this.expectAResponseContaining("squirrels were observed");
+        this.expectAHomePageResponseWith(status().isOk(), "squirrels were observed");
       }
     }
   }
 
-  private void expectAResponseContaining(String substring) throws Exception {
+  private void expectAHomePageResponseWith(ResultMatcher status, String substring)
+      throws Exception {
     this.mockMvc
         .perform(get("/"))
         .andDo(print())
-        .andExpect(status().isOk())
+        .andExpect(status)
         .andExpect(content().string(containsString(substring)));
   }
 }

--- a/app/java/src/test/java/com/google/cloudclientapi/CensusApplicationTest.java
+++ b/app/java/src/test/java/com/google/cloudclientapi/CensusApplicationTest.java
@@ -91,12 +91,12 @@ class CensusApplicationTest {
     }
   }
 
-  private void expectAHomePageResponseWith(ResultMatcher status, String substring)
+  private void expectAHomePageResponseWith(ResultMatcher httpResponseStatus, String substring)
       throws Exception {
     this.mockMvc
         .perform(get("/"))
         .andDo(print())
-        .andExpect(status)
+        .andExpect(httpResponseStatus)
         .andExpect(content().string(containsString(substring)));
   }
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -17,7 +17,7 @@
 locals {
   unique = "${var.deployment_name}-${random_id.default.hex}"
 
-  application_image = "us-docker.pkg.dev/hsa-public/containers/cloud-client-api/${lower(var.language)}:${var.image_version}"
+  application_image = "us-docker.pkg.dev/hsa-public/containers/cloud-client-api/${lower(var.language)}:${var.image_version}-pr86"
 }
 
 resource "random_id" "default" {


### PR DESCRIPTION
* Currently, both the JavaScript (Node.js) app and the Python app respond with a 500 status error if the `PROCESSED_DATA_BUCKET` environment variable is empty/unset.
* See related Node.js/JavaScript code: https://github.com/GoogleCloudPlatform/terraform-cloud-client-api/blob/7463f0f01607bc79489e82be1fcfe61ace703836/app/nodejs/app.js#L34 
* This pull-request makes the Java app do the same.
* See screenshot below of what this looks like:
<img width="1184" alt="Screenshot 2024-05-09 at 3 03 13 PM" src="https://github.com/GoogleCloudPlatform/terraform-cloud-client-api/assets/10292865/52f92a52-bcae-4f41-87ae-aa1c0cc400c4">
* I found this guide useful: https://spring.io/blog/2013/11/01/exception-handling-in-spring-mvc