### PR TITLE
fix: Set /infra/test/setup TF required_version to >= 1.5

### DIFF
--- a/infra/test/setup/versions.tf
+++ b/infra/test/setup/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.5"
   required_providers {
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
* See https://github.com/GoogleCloudPlatform/terraform-cloud-client-api/pull/169.
* In the above pull-request, I forgot to bump the required_version in the `/infra/test/setup` Terraform module.
* Background: The `/infra/test/setup` Terraform module is used to create the Google Cloud projects created for our integration tests.