### PR TITLE
fix: untag pack builders (default google-22)

### DIFF
--- a/build/images.cloudbuild.yaml
+++ b/build/images.cloudbuild.yaml
@@ -21,7 +21,7 @@ steps:
     args:
       - build
       - ${_IMAGE_LOCATION}/python:$TAG_NAME
-      - --builder=gcr.io/buildpacks/builder:v1
+      - --builder=gcr.io/buildpacks/builder
 
 
   - id: nodejs build
@@ -32,7 +32,7 @@ steps:
     args:
       - build
       - ${_IMAGE_LOCATION}/nodejs:$TAG_NAME
-      - --builder=gcr.io/buildpacks/builder:v1
+      - --builder=gcr.io/buildpacks/builder
 
 
   - id: java build
@@ -43,7 +43,7 @@ steps:
     args:
       - build
       - ${_IMAGE_LOCATION}/java:$TAG_NAME
-      - --builder=gcr.io/buildpacks/builder:v1
+      - --builder=gcr.io/buildpacks/builder
 
 
 images:


### PR DESCRIPTION
Update the pack builders to use the latest version (google-22)

For Python 3.12, this appears to be only available in the google-22 builder, as if the builder is ubuntu18 the build fails because 3.12 isn't found. https://cloud.google.com/docs/buildpacks/builders

🛠️ Fixes build failures in #155 
